### PR TITLE
Add example for removing row and column titles in heatmaps

### DIFF
--- a/vignettes/introduction.Rmd
+++ b/vignettes/introduction.Rmd
@@ -613,7 +613,7 @@ You can completely remove the row and column titles by setting them to empty str
 
 ```{r removetitles, fig.width=10, fig.height=10}
 mtcars_tidy |> 
-	mutate(`Car name` = forcats::fct_reorder(`Car name`, `Car name`, .desc = TRUE)) %>% 
+	mutate(`Car name` = forcats::fct_reorder(`Car name`, `Car name`, .desc = TRUE)) |> 
 	heatmap(
 		`Car name`, Property, Value,	
 		scale = "row", 


### PR DESCRIPTION
- Introduced a new section in the introduction vignette demonstrating how to remove row and column titles by setting them to empty strings in the heatmap function.
- Included a code snippet to illustrate the usage.