### PR TITLE
comment out citation message

### DIFF
--- a/R/methods.R
+++ b/R/methods.R
@@ -278,7 +278,7 @@ heatmap_ <-
 		if(scale %in% c("none", "row", "column", "both") |> not()) stop("tidyHeatmap says: the scale parameter has to be one of c(\"none\", \"row\", \"column\", \"both\")")
 		
 		# Citation reminder message, once per session
-		rlang::inform("tidyHeatmap says: If you use tidyHeatmap for scientific research, please cite: Mangiola, S. and Papenfuss, A.T., 2020. 'tidyHeatmap: an R package for modular heatmap production based on tidy principles.' Journal of Open Source Software. doi:10.21105/joss.02472.", .frequency = "once", .frequency_id = "tidyHeatmap_citation_reminder")
+		# rlang::inform("tidyHeatmap says: citing visualisation tools helps sustainable development: Mangiola, S. et al., 2020. JOSS", .frequency = "once", .frequency_id = "tidyHeatmap_citation_reminder")
 		
 		.row = enquo(.row)
 		.column = enquo(.column)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Only removes a one-time informational message; no data processing or plotting logic is changed.
> 
> **Overview**
> The `heatmap_()` implementation no longer emits the session-level citation reminder via `rlang::inform()` (the call is now commented out).
> 
> No functional changes to heatmap construction or validation beyond suppressing this user-facing message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9c70d83f84986f0dd80ce18757b6bf42533483f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->